### PR TITLE
Fixed annoying deprecation warning for 1d array in BallTree

### DIFF
--- a/examples/cluster/plot_optics.py
+++ b/examples/cluster/plot_optics.py
@@ -5,8 +5,6 @@ Demo of OPTICS clustering algorithm
 
 Finds core samples of high density and expands clusters from them.
 """
-from sklearn.datasets.samples_generator import make_blobs
-from sklearn.preprocessing import StandardScaler
 from sklearn.cluster.optics import OPTICS
 import numpy as np
 
@@ -19,19 +17,19 @@ np.random.seed(0)
 n_points_per_cluster = 250
 
 X = np.empty((0, 2))
-X = np.r_[X, [-5,-2] + .8 * np.random.randn(n_points_per_cluster, 2)]
-X = np.r_[X, [4,-1] + .1 * np.random.randn(n_points_per_cluster, 2)]
-X = np.r_[X, [1,-2] + .2 * np.random.randn(n_points_per_cluster, 2)]
-X = np.r_[X, [-2,3] + .3 * np.random.randn(n_points_per_cluster, 2)]
-X = np.r_[X, [3,-2] + 1.6 * np.random.randn(n_points_per_cluster, 2)]
-X = np.r_[X, [5,6] + 2 * np.random.randn(n_points_per_cluster, 2)]
+X = np.r_[X, [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)]
+X = np.r_[X, [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)]
+X = np.r_[X, [1, -2] + .2 * np.random.randn(n_points_per_cluster, 2)]
+X = np.r_[X, [-2, 3] + .3 * np.random.randn(n_points_per_cluster, 2)]
+X = np.r_[X, [3, -2] + 1.6 * np.random.randn(n_points_per_cluster, 2)]
+X = np.r_[X, [5, 6] + 2 * np.random.randn(n_points_per_cluster, 2)]
 
 ##############################################################################
-#plot scatterplot of points
+# plot scatterplot of points
 
 fig = plt.figure()
 ax = fig.add_subplot(111)
-ax.plot(X[:,0], X[:,1], 'b.', ms=2)
+ax.plot(X[:, 0], X[:, 1], 'b.', ms=2)
 
 ##############################################################################
 # Compute OPTICS
@@ -68,10 +66,10 @@ for k, col in zip(unique_labels, colors):
 plt.title('Estimated number of clusters: %d' % clust.n_clusters)
 plt.show()
 
-# (Re)-extract clustering structure, using a single eps to show comparison with DBSCAN. 
-# This can be run for any clustering distance, 
-# and can be run multiple times without rerunning OPTICS
-# OPTICS does need to be re-run to change the min-pts parameter
+# (Re)-extract clustering structure, using a single eps to show comparison
+# with DBSCAN. This can be run for any clustering distance, and can be run
+# multiple times without rerunning OPTICS. OPTICS does need to be re-run to c
+# hange the min-pts parameter.
 
 clust.extract(.15, 'dbscan')
 
@@ -102,7 +100,7 @@ plt.show()
 # Try with different eps to highlight the problem
 
 
-clust.extract(.4,'dbscan')
+clust.extract(.4, 'dbscan')
 
 
 core_samples_mask = np.zeros_like(clust.labels_, dtype=bool)

--- a/sklearn/cluster/optics.py
+++ b/sklearn/cluster/optics.py
@@ -13,7 +13,6 @@ Dates: May 2013 (implemented), Sept 2015 (Benchmarked), Aug 2016 (updated)
 
 import scipy as sp
 import numpy as np
-import sys
 from ..utils import check_array
 from sklearn.neighbors import BallTree
 from sklearn.base import BaseEstimator, ClusterMixin
@@ -110,7 +109,8 @@ def _set_reach_dist(setofobjects, point_index, epsilon):
     # Assumes that the query returns ordered (smallest distance first)
     # entries. This is the case for the balltree query...
 
-    dists, indices = setofobjects.query(setofobjects.data[point_index],
+    X = np.array(setofobjects.data[point_index]).reshape(1, -1)
+    dists, indices = setofobjects.query(X,
                                         setofobjects._nneighbors[point_index])
 
     # Checks to see if there more than one member in the neighborhood ##
@@ -224,7 +224,7 @@ class OPTICS(BaseEstimator, ClusterMixin):
         # _extractDBSCAN(self, self.eps)  # extraction needs to be < eps
         _extract_auto(self)
         self.labels_ = self._cluster_id[:]
-        self.core_sample_indices_ = self._index[self._is_core[:] == True]
+        self.core_sample_indices_ = self._index[self._is_core[:]]
         self.n_clusters = max(self._cluster_id)
         self.processed = True
         return self  # self.core_sample_indices_, self.labels_
@@ -244,7 +244,6 @@ class OPTICS(BaseEstimator, ClusterMixin):
         Returns
         Either boolean or indexed array of core / not core points
         """
-
         if self.processed is False:
             # epsilon has no impact on this method; set to zero
             # to speed up _nneighbors query in _prep_optics
@@ -427,8 +426,7 @@ def _find_local_maxima(RPlot, RPoints, nghsize):
         # if the point is a local maxima on the reachability plot with
         # regard to nghsize, insert it into priority queue and maxima list
         if (RPlot[i] > RPlot[i-1] and RPlot[i] >= RPlot[i+1] and
-            _is_local_maxima(i, RPlot, RPoints, nghsize) == 1):
-
+                _is_local_maxima(i, RPlot, RPoints, nghsize) == 1):
             localMaximaPoints[i] = RPlot[i]
 
     return sorted(localMaximaPoints,
@@ -523,10 +521,12 @@ def _cluster_tree(node, parentNode, localMaximaPoints,
             return
 
     # remove clusters that are too small
-    if len(Node1.points) < min_cluster_size and Nodelist.count((Node1, LocalMax1)) > 0:
-        # cluster 1 is too small"
+    if (len(Node1.points) < min_cluster_size
+            and Nodelist.count((Node1, LocalMax1)) > 0):
+        # cluster 1 is too small
         Nodelist.remove((Node1, LocalMax1))
-    if len(Node2.points) < min_cluster_size and Nodelist.count((Node2, LocalMax1)) > 0:
+    if (len(Node2.points) < min_cluster_size
+            and Nodelist.count((Node2, LocalMax1)) > 0):
         # cluster 2 is too small
         Nodelist.remove((Node2, LocalMax2))
     if len(Nodelist) == 0:
@@ -546,12 +546,14 @@ def _cluster_tree(node, parentNode, localMaximaPoints,
     similaritythreshold = 0.4
     bypassNode = 0
     if parentNode is not None:
-        sumRP = np.average(RPlot[node.start:node.end])
-        sumParent = np.average(RPlot[parentNode.start:parentNode.end])
         if (float(float(node.end-node.start) /
                   float(parentNode.end-parentNode.start)) >
-            similaritythreshold):  # 1)
-        # if float(float(sumRP) / float(sumParent)) > similaritythreshold: # 2)
+                similaritythreshold):
+
+            # sumRP = np.average(RPlot[node.start:node.end])
+            # sumParent = np.average(RPlot[parentNode.start:parentNode.end])
+            # if float(float(sumRP) / float(sumParent)) > similaritythreshold:
+
             parentNode.children.remove(node)
             bypassNode = 1
 

--- a/sklearn/cluster/optics.py
+++ b/sklearn/cluster/optics.py
@@ -521,12 +521,12 @@ def _cluster_tree(node, parentNode, localMaximaPoints,
             return
 
     # remove clusters that are too small
-    if (len(Node1.points) < min_cluster_size
-            and Nodelist.count((Node1, LocalMax1)) > 0):
+    if (len(Node1.points) < min_cluster_size and
+            Nodelist.count((Node1, LocalMax1)) > 0):
         # cluster 1 is too small
         Nodelist.remove((Node1, LocalMax1))
-    if (len(Node2.points) < min_cluster_size
-            and Nodelist.count((Node2, LocalMax1)) > 0):
+    if (len(Node2.points) < min_cluster_size and
+            Nodelist.count((Node2, LocalMax1)) > 0):
         # cluster 2 is too small
         Nodelist.remove((Node2, LocalMax2))
     if len(Nodelist) == 0:

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -4,14 +4,12 @@ from sklearn.utils.testing import assert_equal, assert_greater_equal
 from .common import generate_clustered_data
 import numpy as np
 
+
 def test_optics():
     '''
     Tests the optics clustering method and all functions inside it
     'auto' mode
     '''
-
-
-    ##########################################################################
 
     n_clusters = 3
     X = generate_clustered_data(n_clusters=n_clusters)
@@ -23,6 +21,7 @@ def test_optics():
     n_clusters_1 = len(set(clust.labels_)) - int(-1 in clust.labels_)
     assert_equal(n_clusters_1, n_clusters)
 
+
 def test_filter():
     '''
     Tests the filter function.
@@ -30,6 +29,7 @@ def test_filter():
 
     n_clusters = 3
     X = generate_clustered_data(n_clusters=n_clusters)
+    print np.array(X).shape
     # Parameters chosen specifically for this task.
     clust = OPTICS(eps=6.0, min_samples=4, metric='euclidean')
     # Run filter (before computing OPTICS)
@@ -39,13 +39,14 @@ def test_filter():
     assert_equal(sum(bool_memb), len(idx_memb))
     # Compute OPTICS
     clust.fit(X)
-    clust.extract(0.5,clustering='dbscan')
+    clust.extract(0.5, clustering='dbscan')
     # core points from filter and extract should be the same within 1 point,
-    # with extract occasionally underestimating due to start point of the 
-    # OPTICS algorithm. Here we test for at least 95% similarity in 
+    # with extract occasionally underestimating due to start point of the
+    # OPTICS algorithm. Here we test for at least 95% similarity in
     # classification of core/not core
     agree = sum(clust._is_core == bool_memb)
-    assert_greater_equal(float(agree)/len(X),0.95)
+    assert_greater_equal(float(agree)/len(X), 0.95)
+
 
 def test_optics2():
     '''
@@ -53,17 +54,16 @@ def test_optics2():
     'dbscan' mode
     '''
 
-
-    ##########################################################################
     # Compute OPTICS
-    X = [[1,1]]
+    X = [[1, 1]]
+    print np.array(X).shape
     clust = OPTICS(eps=0.3, min_samples=10)
 
     # Run the fit
 
     clust2 = clust.fit(X)
 
-    assert clust2 == None
+    assert clust2 is None
     # samples, labels = clust2.extract(0.4, 'dbscan')
 
     # assert samples.size == 0
@@ -74,15 +74,17 @@ def test_empty_extract():
     '''
     Test extract where fit() has not yet been run.
     '''
+
     clust = OPTICS(eps=0.3, min_samples=10)
-    assert clust.extract(0.01, clustering='auto') == None
+    assert clust.extract(0.01, clustering='auto') is None
+
 
 def test_bad_extract():
     '''
     Test an extraction of eps too close to original eps
     '''
     centers = [[1, 1], [-1, -1], [1, -1]]
-    X, labels_true = make_blobs(n_samples=750, centers=centers, 
+    X, labels_true = make_blobs(n_samples=750, centers=centers,
                                 cluster_std=0.4, random_state=0)
 
     ##########################################################################
@@ -90,15 +92,17 @@ def test_bad_extract():
 
     clust = OPTICS(eps=0.003, min_samples=10)
     clust2 = clust.fit(X)
-    assert clust2.extract(0.3) == None
+    assert clust2.extract(0.3) is None
+
 
 def test_close_extract():
     '''
     Test extract where extraction eps is close to scaled epsPrime
     '''
     centers = [[1, 1], [-1, -1], [1, -1]]
-    X, labels_true = make_blobs(n_samples=750, centers=centers, 
+    X, labels_true = make_blobs(n_samples=750, centers=centers,
                                 cluster_std=0.4, random_state=0)
+    print np.array(X).shape
 
     # Compute OPTICS
 
@@ -107,6 +111,7 @@ def test_close_extract():
     clust3.extract(0.3, clustering='dbscan')
     assert max(clust3.labels_) == 3
 
+
 def test_auto_extract_hier():
     # Generate sample data
 
@@ -114,12 +119,14 @@ def test_auto_extract_hier():
     n_points_per_cluster = 250
 
     X = np.empty((0, 2))
-    X = np.r_[X, [-5,-2] + .8 * np.random.randn(n_points_per_cluster, 2)]
-    X = np.r_[X, [4,-1] + .1 * np.random.randn(n_points_per_cluster, 2)]
-    X = np.r_[X, [1,-2] + .2 * np.random.randn(n_points_per_cluster, 2)]
-    X = np.r_[X, [-2,3] + .3 * np.random.randn(n_points_per_cluster, 2)]
-    X = np.r_[X, [3,-2] + 1.6 * np.random.randn(n_points_per_cluster, 2)]
-    X = np.r_[X, [5,6] + 2 * np.random.randn(n_points_per_cluster, 2)]
+    X = np.r_[X, [-5, -2] + .8 * np.random.randn(n_points_per_cluster, 2)]
+    X = np.r_[X, [4, -1] + .1 * np.random.randn(n_points_per_cluster, 2)]
+    X = np.r_[X, [1, -2] + .2 * np.random.randn(n_points_per_cluster, 2)]
+    X = np.r_[X, [-2, 3] + .3 * np.random.randn(n_points_per_cluster, 2)]
+    X = np.r_[X, [3, -2] + 1.6 * np.random.randn(n_points_per_cluster, 2)]
+    X = np.r_[X, [5, 6] + 2 * np.random.randn(n_points_per_cluster, 2)]
+    print np.array(X).shape
+
     # Compute OPTICS
 
     clust = OPTICS(eps=30.3, min_samples=9)
@@ -128,6 +135,7 @@ def test_auto_extract_hier():
     clust.fit(X)
 
     # Extract the result
-    clust.extract(0.0, 'auto') # eps not used for 'auto' extract
+    # eps not used for 'auto' extract
+    clust.extract(0.0, 'auto')
 
     assert_equal(len(set(clust.labels_)), 6)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -29,7 +29,6 @@ def test_filter():
 
     n_clusters = 3
     X = generate_clustered_data(n_clusters=n_clusters)
-    print np.array(X).shape
     # Parameters chosen specifically for this task.
     clust = OPTICS(eps=6.0, min_samples=4, metric='euclidean')
     # Run filter (before computing OPTICS)
@@ -56,7 +55,6 @@ def test_optics2():
 
     # Compute OPTICS
     X = [[1, 1]]
-    print np.array(X).shape
     clust = OPTICS(eps=0.3, min_samples=10)
 
     # Run the fit
@@ -102,7 +100,6 @@ def test_close_extract():
     centers = [[1, 1], [-1, -1], [1, -1]]
     X, labels_true = make_blobs(n_samples=750, centers=centers,
                                 cluster_std=0.4, random_state=0)
-    print np.array(X).shape
 
     # Compute OPTICS
 
@@ -125,7 +122,6 @@ def test_auto_extract_hier():
     X = np.r_[X, [-2, 3] + .3 * np.random.randn(n_points_per_cluster, 2)]
     X = np.r_[X, [3, -2] + 1.6 * np.random.randn(n_points_per_cluster, 2)]
     X = np.r_[X, [5, 6] + 2 * np.random.randn(n_points_per_cluster, 2)]
-    print np.array(X).shape
 
     # Compute OPTICS
 


### PR DESCRIPTION
Fixed BallTree deprecation warning by reshaping input at `sklearn/cluster/optics.py:113`. 

PEP8 formatting fixes. 
